### PR TITLE
[misc] Add .editorconfig 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+tab_width = 2
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Purpose of pull request

Mostly copied from message on 462a8ae:

While we already have Prettier, adding a .editorconfig sets the correct default editor settings in an editor-agnostic way. Most JavaScript projects use .editorconfig regardless of whether they use a code formatter like Prettier. It's not a super big deal, but it's a nice convenience feature. 

## Pull request checklist

- [x] Branch and PR are named correctly
- [ ] Updated relevant documentation
I don't think that this needs to be mentioned in step 2 of the contributing guidelines since it's not explicitly required. If you disagree, I could mention it there. 
- [ ] Tested with a tester bot
- [ ] Wrote unit tests for changes

## Testing instructions

If your [editor does not support .editorconfig out of the box](https://editorconfig.org), you'll need a plugin/extension to test this. I can confirm that it works correctly with Sublime Text 3 and [this package](https://github.com/sindresorhus/editorconfig-sublime#readme). 
