### PR TITLE
[bug] Linter not catching base folder js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve": "node lib/index.js",
     "coverage": "jest --coverage",
     "test": "jest",
-    "lint": "eslint src/**/*.js"
+    "lint": "eslint src/**/*.js src/*.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: N/A

Linter misses the base index.js file (`src/index.js`), so any errors there are not caught.

### Pull request checklist

- [x] Branch and PR are named correctly
- [x] Updated relevant documentation
- [ ] Tested with a tester bot
- [ ] Wrote unit tests for changes

### Testing instructions

Automated testing should catch it here
