### PR TITLE
[bug] Make nodemon use babel correctly on changes (fix #35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "build": "babel src -d lib --ignore **/*.test.js",
-    "start": "yarn build && nodemon lib/index.js",
+    "start": "nodemon",
     "serve": "node lib/index.js",
     "coverage": "jest --coverage",
     "test": "jest",
@@ -34,5 +34,13 @@
     "mongoose": "^5.11.4",
     "superagent": "^3.5.2",
     "winston": "^2.3.1"
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "lib/*"
+    ],
+    "exec": [
+      "yarn build && yarn serve"
+    ]
   }
 }


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: resolves #35 and [this issue](https://discord.com/channels/334891772696330241/340316853001912330/785358242959065128)

Nodemon did not actually update the code it ran when changes were made because it only ran Babel once. This PR fixes that. 

### Pull request checklist

- [x] Branch and PR are named correctly
- [ ] Updated relevant documentation
No usage changes
- [x] Tested with a tester bot
- [ ] Wrote unit tests for changes

### Testing instructions

Try `yarn start` and change a file. Notice that Babel runs again. 
