### PR TITLE
[feature] Add timeout to GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -30,6 +30,8 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [14.x]

--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
     strategy:
       matrix:
         node-version: [14.x]


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: N/A

Add an upper limit to the testing time, to prevent Actions hitting 72hrs.
Current setting is _10_ minutes. This may be extended in the future but right now this should leave substantial room for current amount.

### Pull request checklist

- [x] Branch and PR are named correctly
- [ ] Updated relevant documentation
- [ ] Tested with a tester bot
- [ ] Wrote unit tests for changes

### Testing instructions

Hopefully not have to hit that mark.
