### PR TITLE
add message deletion if not in DM channel

### DIFF
--- a/src/bots/modchat/messageHandler.js
+++ b/src/bots/modchat/messageHandler.js
@@ -19,6 +19,7 @@ let handlePrivateMessage = async () => {
   }
 
   if (!(channel instanceof DMChannel)) {
+    client.message.delete();
     channel.send(defaultStrings.dmOnly);
     return;
   }

--- a/src/bots/modchat/tests/messageHandler.test.js
+++ b/src/bots/modchat/tests/messageHandler.test.js
@@ -13,7 +13,8 @@ describe('handlePrivateMessage', () => {
       },
       channel: {
         send: jest.fn()
-      }
+      },
+      delete: jest.fn()
     };
 
     client.prefix = '++';
@@ -34,6 +35,7 @@ describe('handlePrivateMessage', () => {
 
     await handlePrivateMessage();
 
+    expect(client.message.delete).toHaveBeenCalled();
     expect(client.message.channel.send).toHaveBeenCalledWith(
       defaultStrings.dmOnly
     );


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: resolves #102

Deletes a person's message if they sent a PM in a public channel

### Pull request checklist

- [x] Branch and PR are named correctly
- [x] Updated relevant documentation
- [x] Tested with a tester bot
- [x] Wrote unit tests for changes

### Testing instructions

do `++mc insert message here` in a non-DM channel and it should be deleted with a warning
