### PR TITLE
[feature] Set invalid permission messages to be private not in public

### DIFF
--- a/src/bots/ama/subCommands/deleteEvent.js
+++ b/src/bots/ama/subCommands/deleteEvent.js
@@ -13,7 +13,7 @@ const handler = async (args) => {
   }
 
   if (args.length !== 1) {
-    client.message.channel.send(strings.insufficientArgumentsDeleteEvent);
+    client.message.author.send(strings.insufficientArgumentsDeleteEvent);
     return;
   }
 

--- a/src/bots/ama/subCommands/tests/deleteEvent.test.js
+++ b/src/bots/ama/subCommands/tests/deleteEvent.test.js
@@ -13,6 +13,10 @@ describe('deleting Event', () => {
 
   beforeAll(async () => {
     client.message = {
+      author: {
+        send: jest.fn()
+      },
+
       channel: {
         send: jest.fn()
       }
@@ -34,9 +38,10 @@ describe('deleting Event', () => {
   });
 
   test('ama returns error message when no arguments passed in', async () => {
+    jest.spyOn(permUtils, 'isMod').mockImplementation(() => true);
     await deleteEvent.handler([]);
 
-    expect(client.message.channel.send).toHaveBeenCalledWith(
+    expect(client.message.author.send).toHaveBeenCalledWith(
       strings.insufficientArgumentsDeleteEvent
     );
   });
@@ -45,13 +50,13 @@ describe('deleting Event', () => {
     jest
       .spyOn(permUtils, 'insufficientPermissionsAlert')
       .mockImplementationOnce(() => {
-        client.message.channel.send(defaultStrings.insufficientPermissions);
+        client.message.author.send(defaultStrings.insufficientPermissions);
         return true;
       });
 
     await deleteEvent.handler([]);
 
-    expect(client.message.channel.send).toHaveBeenCalledWith(
+    expect(client.message.author.send).toHaveBeenCalledWith(
       defaultStrings.insufficientPermissions
     );
   });

--- a/src/bots/modchat/messageHandler.js
+++ b/src/bots/modchat/messageHandler.js
@@ -12,15 +12,16 @@ import { getModChannel, parseCommandString } from '../../utils/index';
 let handlePrivateMessage = async () => {
   let cmd = parseCommandString();
   let channel = client.message.channel;
+  let author = client.message.author;
 
   if (cmd.arguments.length === 0) {
-    channel.send(strings.explanation);
+    author.send(strings.explanation);
     return;
   }
 
   if (!(channel instanceof DMChannel)) {
     client.message.delete();
-    channel.send(defaultStrings.dmOnly);
+    author.send(defaultStrings.dmOnly);
     return;
   }
 

--- a/src/bots/modchat/tests/messageHandler.test.js
+++ b/src/bots/modchat/tests/messageHandler.test.js
@@ -9,6 +9,7 @@ describe('handlePrivateMessage', () => {
     client.message = {
       author: {
         discriminator: 1234,
+        send: jest.fn(),
         username: 'test-user'
       },
       channel: {
@@ -25,7 +26,7 @@ describe('handlePrivateMessage', () => {
 
     await handlePrivateMessage();
 
-    expect(client.message.channel.send).toHaveBeenCalledWith(
+    expect(client.message.author.send).toHaveBeenCalledWith(
       strings.explanation
     );
   });
@@ -36,7 +37,7 @@ describe('handlePrivateMessage', () => {
     await handlePrivateMessage();
 
     expect(client.message.delete).toHaveBeenCalled();
-    expect(client.message.channel.send).toHaveBeenCalledWith(
+    expect(client.message.author.send).toHaveBeenCalledWith(
       defaultStrings.dmOnly
     );
   });

--- a/src/bots/pins/subCommands/pinByReaction.js
+++ b/src/bots/pins/subCommands/pinByReaction.js
@@ -1,6 +1,11 @@
 import client from '../../../client';
 import { defaultStrings } from '../../../constants';
-import { getMemberFromUser, isContributor, isMod } from '../../../utils/perms';
+import {
+  checkRuleList,
+  getMemberFromUser,
+  isContributor,
+  isMod
+} from '../../../utils/perms';
 import { pinEmoji, strings } from '../constants';
 
 /**
@@ -13,10 +18,11 @@ import { pinEmoji, strings } from '../constants';
 const pinByReaction = async (reaction, user, action) => {
   if (reaction.emoji.name === pinEmoji) {
     const member = await getMemberFromUser(user);
-    if (isContributor(member) || isMod(member)) {
+
+    if (checkRuleList(member, [isMod, isContributor])) {
       pin(reaction, action);
     } else {
-      reaction.message.channel.send(defaultStrings.insufficientPermissions);
+      member.send(defaultStrings.insufficientPermissions);
     }
   }
 };

--- a/src/bots/pins/subCommands/tests/pinByReaction.test.js
+++ b/src/bots/pins/subCommands/tests/pinByReaction.test.js
@@ -24,18 +24,23 @@ describe('pinByReaction', () => {
     }
   };
 
+  const user = {};
+  const member = {
+    send: jest.fn()
+  };
+
   jest.spyOn(permUtils, 'getMemberFromUser').mockImplementation(() => {
-    return {};
+    return member;
   });
 
   test('messages when user has no permission', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => false);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => false);
-    const user = {};
+
     const action = 'add';
     await pinByReaction(reaction, user, action);
 
-    expect(reaction.message.channel.send).toHaveBeenCalledWith(
+    expect(member.send).toHaveBeenCalledWith(
       defaultStrings.insufficientPermissions
     );
   });
@@ -43,37 +48,37 @@ describe('pinByReaction', () => {
   test('does not message when user has permission', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => true);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => true);
-    const user = {};
+
     const action = 'add';
     await pinByReaction(reaction, user, action);
 
-    expect(reaction.message.channel.send).not.toHaveBeenCalled();
+    expect(member.send).not.toHaveBeenCalled();
   });
 
   test('does not message when user has Contributor role but not Mod role', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => false);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => true);
-    const user = {};
+
     const action = 'add';
     await pinByReaction(reaction, user, action);
 
-    expect(reaction.message.channel.send).not.toHaveBeenCalled();
+    expect(member.send).not.toHaveBeenCalled();
   });
 
   test('does not message when user has Mod role but not Contributor role', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => true);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => false);
-    const user = {};
+
     const action = 'add';
     await pinByReaction(reaction, user, action);
 
-    expect(reaction.message.channel.send).not.toHaveBeenCalled();
+    expect(member.send).not.toHaveBeenCalled();
   });
 
   test('calls pin when add action is passed', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => true);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => true);
-    const user = {};
+
     const action = 'add';
     await pinByReaction(reaction, user, action);
 
@@ -83,7 +88,7 @@ describe('pinByReaction', () => {
   test('calls unpin when remove action is passed', async () => {
     jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => true);
     jest.spyOn(permUtils, 'isContributor').mockImplementationOnce(() => true);
-    const user = {};
+
     const action = 'remove';
     await pinByReaction(reaction, user, action);
 

--- a/src/bots/settings/subCommands/tests/updateEnvVar.test.js
+++ b/src/bots/settings/subCommands/tests/updateEnvVar.test.js
@@ -7,9 +7,11 @@ import * as permUtils from '../../../../utils/perms';
 
 describe('setting environment variable change', () => {
   beforeEach(async () => {
-    jest.spyOn(permUtils, 'isMod').mockImplementation(() => true);
-
     client.message = {
+      author: {
+        send: jest.fn()
+      },
+
       channel: {
         id: 12321,
         send: jest.fn()
@@ -18,16 +20,29 @@ describe('setting environment variable change', () => {
   });
 
   test('settings returns error message when insufficient permissions', async () => {
-    jest.spyOn(permUtils, 'isMod').mockImplementationOnce(() => false);
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => {
+        client.message.author.send(defaultStrings.insufficientPermissions);
+        return true;
+      });
 
     await updateEnvVar.handler([]);
 
-    expect(client.message.channel.send).toHaveBeenCalledWith(
+    expect(client.message.author.send).toHaveBeenCalledWith(
       defaultStrings.insufficientPermissions
     );
+
+    expect(client.message.channel.send).not.toHaveBeenCalled();
   });
 
   test('settings returns error message when insufficient arguments', async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => {
+        return false;
+      });
+
     await updateEnvVar.handler([]);
 
     expect(client.message.channel.send).toHaveBeenCalledWith(
@@ -36,6 +51,12 @@ describe('setting environment variable change', () => {
   });
 
   test('settings returns error message when invalid variable being set', async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => {
+        return false;
+      });
+
     await updateEnvVar.handler(['TEST_TOKEN', 'IDKLOL']);
 
     expect(client.message.channel.send).toHaveBeenCalledWith(
@@ -44,6 +65,12 @@ describe('setting environment variable change', () => {
   });
 
   test('settings updates command prefix', async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => {
+        return false;
+      });
+
     await updateEnvVar.handler(['BOT_PREFIX', '-+-']);
 
     expect(process.env['BOT_PREFIX']).toEqual('-+-');

--- a/src/bots/settings/subCommands/updateEnvVar.js
+++ b/src/bots/settings/subCommands/updateEnvVar.js
@@ -1,16 +1,14 @@
 import client from '../../../client';
-import { defaultStrings } from '../../../constants';
+import { insufficientPermissionsAlert } from '../../../utils/perms';
 import { strings } from '../constants';
 import { environmentElements, get, updateElement } from '../../../environment';
-import { getMemberFromMessage, isMod } from '../../../utils/perms';
 
 /**
  * Handles updating environment variables and client prefix.
  * @param {Array.<string>} args - size 2 length array corresponding to [variable name, new variable value]
  */
 const handler = async (args) => {
-  if (!isMod(getMemberFromMessage())) {
-    client.message.channel.send(defaultStrings.insufficientPermissions);
+  if (insufficientPermissionsAlert()) {
     return;
   }
 

--- a/src/utils/perms.js
+++ b/src/utils/perms.js
@@ -73,7 +73,11 @@ export const isContributor = (member) => {
   return (
     member.roles &&
     (highestRole(member).name.endsWith('Contributor') ||
+<<<<<<< HEAD
       findRole(member, 'Contributor', true))
+=======
+      findRole(member, 'Contributor'))
+>>>>>>> ed2fa49 (Change the way contributor is perceived)
   );
 };
 

--- a/src/utils/perms.js
+++ b/src/utils/perms.js
@@ -49,10 +49,31 @@ export const highestRole = (member) => {
  * @returns {boolean} - whether or not the member has insufficient permissions
  */
 export const insufficientPermissionsAlert = () => {
-  if (!isMod(getMemberFromMessage())) {
-    client.message.channel.send(defaultStrings.insufficientPermissions);
+  if (!checkRuleList(getMemberFromMessage(), [isMod])) {
+    client.message.author.send(defaultStrings.insufficientPermissions);
     return true;
   }
+
+  return false;
+};
+
+/**
+ * Checks a rule list for a member and returns true if at least one rule applies.
+ * Default rule set is [isMod, isContributor, isAdmin].
+ *
+ * @param {Object.<string, any>} member - the GuildMember object
+ * @param {Array.<function>} rules - rules to be applied to a member
+ * @returns
+ */
+export const checkRuleList = (
+  member,
+  rules = [isMod, isContributor, isAdmin]
+) => {
+  if (rules.some((rule) => rule.apply(member))) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/src/utils/perms.js
+++ b/src/utils/perms.js
@@ -69,11 +69,7 @@ export const checkRuleList = (
   member,
   rules = [isMod, isContributor, isAdmin]
 ) => {
-  if (rules.some((rule) => rule.apply(member))) {
-    return true;
-  }
-
-  return false;
+  return rules.some((rule) => rule(member));
 };
 
 /**

--- a/src/utils/perms.js
+++ b/src/utils/perms.js
@@ -73,11 +73,7 @@ export const isContributor = (member) => {
   return (
     member.roles &&
     (highestRole(member).name.endsWith('Contributor') ||
-<<<<<<< HEAD
       findRole(member, 'Contributor', true))
-=======
-      findRole(member, 'Contributor'))
->>>>>>> ed2fa49 (Change the way contributor is perceived)
   );
 };
 


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: resolves #108

Sets all invalid messages to be DMs now

### Pull request checklist

- [x] Branch and PR are named correctly
- [x] Updated relevant documentation
- [x] Tested with a tester bot
- [x] Wrote unit tests for changes

### Testing instructions

1. Have a user with insufficient permissions for certain action
2. Have them try pin/update variable/add event
3. Should see the dm of failure
