### PR TITLE
[misc] Allow double quotes to be used when they'd avoid ugly escapes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'warn',
     'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
+    quotes: ['error', 'single', { avoidEscape: true }],
     'require-jsdoc': [
       2,
       {


### PR DESCRIPTION
See https://eslint.org/docs/rules/quotes.html#avoidescape for more
information

### Purpose of pull request

**Related Issue**: resolves #123

Fixes the issue described by @nikgil, where linting and formatting would cause sadness.

### Pull request checklist

- [X] Branch and PR are named correctly
- [ not relevant ] Updated relevant documentation
- [ not relevant ] Tested with a tester bot
- [ not relevant ] Wrote unit tests for changes

### Testing instructions

I verified that creating a line with text "Isn't this wonderful" and ran lint + format. Sadness was not caused.
