### PR TITLE
[feature] Add Channel Purge Capability

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -26,4 +26,4 @@ jobs:
             git checkout origin/development
             pm2 flush megabot-dev
             yarn install --production --check-files
-            pm2 stop megabot-dev; pm2 start yarn --interpreter bash --cron-restart="0 0 * * *" --name megabot-dev -- start
+            pm2 stop megabot-dev; pm2 delete megabot-dev; pm2 start yarn --interpreter bash --name megabot-dev -- start; pm2 restart megabot-dev --cron-restart="0 0 * * *"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,4 +26,4 @@ jobs:
             git checkout origin/master
             pm2 flush megabot-prod
             yarn install --production --check-files
-            pm2 stop megabot-prod; pm2 start yarn --interpreter bash --cron-restart="0 0 * * *" --name megabot-prod -- start
+            pm2 stop megabot-prod; pm2 delete megabot-prod; pm2 start yarn --interpreter bash --name megabot-prod -- start; pm2 restart megabot-prod --cron-restart="0 0 * * *"

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ coverage/
 
 *.log
 .env
+.env_backup
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "megabot",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "CSCH megabot with standalone packages",
   "main": "src/index.js",
   "repository": "https://github.com/cscareerhub/megabot.git",

--- a/src/bots/settings/constants.js
+++ b/src/bots/settings/constants.js
@@ -1,4 +1,6 @@
 export const strings = {
+  channelCreated: (user) => `${user} has recreated this channel`,
+  channelNotCreated: 'Channel could not be created. Please try again',
   insufficientArguments: 'You need to supply a variable name and a new value.',
   successfullyUpdated: (oldVar, newVar) =>
     `The ${oldVar} has been updated to ${newVar}.`,

--- a/src/bots/settings/index.js
+++ b/src/bots/settings/index.js
@@ -1,10 +1,12 @@
 import client from '../../client';
 import { commandHandler } from '../../utils';
+import purge from './subCommands/purgeChannel';
 import setDevChannel from './subCommands/setDevChannel';
 import setModChannel from './subCommands/setModChannel';
 import updateElement from './subCommands/updateEnvVar';
 
 const subCommands = {
+  purge: purge,
   setDevChannel: setDevChannel,
   setModChannel: setModChannel,
   update: updateElement

--- a/src/bots/settings/subCommands/purgeChannel.js
+++ b/src/bots/settings/subCommands/purgeChannel.js
@@ -1,0 +1,48 @@
+import client from '../../../client';
+import { insufficientPermissionsAlert } from '../../../utils/perms';
+import { strings } from '../constants';
+import { getElementsForChannelId, updateElement } from '../../../environment';
+
+/**
+ * Purges current channel user is in and recreates a clone.
+ * This is done in settings as it needs env access.
+ */
+const handler = async (args) => {
+  if (insufficientPermissionsAlert()) {
+    return;
+  }
+
+  let newChannel = await client.message.channel.clone();
+
+  if (newChannel === null) {
+    client.message.channel.send(strings.channelNotCreated);
+    return;
+  }
+
+  let ids = getElementsForChannelId(client.message.channel.id);
+
+  for (let channelId of ids) {
+    updateElement(channelId, newChannel.id);
+  }
+
+  if (args.length > 0) {
+    if (args[0].toUpperCase() === 'DELETE') {
+      await client.message.channel.delete();
+    } else {
+      await client.message.channel.updateOverwrite(
+        client.message.guild.roles.everyone,
+        { SEND_MESSAGES: false }
+      );
+    }
+  }
+
+  newChannel.send(strings.channelCreated(client.message.author.toString()));
+};
+
+const purge = {
+  example: 'purge [delete|lock]',
+  handler,
+  usage: 'purges current channel (sets env var if needed)'
+};
+
+export default purge;

--- a/src/bots/settings/subCommands/tests/purgeChannel.test.js
+++ b/src/bots/settings/subCommands/tests/purgeChannel.test.js
@@ -1,0 +1,88 @@
+import client from '../../../../client';
+import purge from '../purgeChannel';
+import * as envUtils from '../../../../environment';
+import * as permUtils from '../../../../utils/perms';
+
+describe('purging channel', () => {
+  let otherChannel = {
+    send: jest.fn()
+  };
+
+  beforeEach(async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementation(() => false);
+
+    client.message = {
+      author: {
+        toString: jest.fn()
+      },
+      channel: {
+        clone: jest.fn(() => otherChannel),
+        delete: jest.fn(),
+        id: 12321,
+        send: jest.fn(),
+        updateOverwrite: jest.fn()
+      },
+      guild: {
+        roles: {
+          everyone: {}
+        }
+      }
+    };
+
+    jest.spyOn(envUtils, 'getElementsForChannelId').mockImplementation(() => {
+      return [];
+    });
+  });
+
+  test('insufficient permissions', async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => true);
+
+    await purge.handler([]);
+
+    expect(client.message.channel.clone).not.toHaveBeenCalled();
+    expect(otherChannel.send).not.toHaveBeenCalled();
+  });
+
+  test('could not create channel', async () => {
+    client.message.clone = jest.fn(() => null);
+
+    purge.handler([]);
+
+    expect(client.message.channel.clone).toHaveBeenCalled();
+    expect(otherChannel.send).not.toHaveBeenCalled();
+  });
+
+  test('no args', async () => {
+    await purge.handler([]);
+
+    expect(client.message.channel.clone).toHaveBeenCalled();
+
+    expect(otherChannel.send).toHaveBeenCalled();
+    expect(client.message.channel.delete).not.toHaveBeenCalled();
+    expect(client.message.channel.updateOverwrite).not.toHaveBeenCalled();
+  });
+
+  test('delete called', async () => {
+    await purge.handler(['delete']);
+
+    expect(client.message.channel.clone).toHaveBeenCalled();
+
+    expect(otherChannel.send).toHaveBeenCalled();
+    expect(client.message.channel.delete).toHaveBeenCalled();
+    expect(client.message.channel.updateOverwrite).not.toHaveBeenCalled();
+  });
+
+  test('lock called', async () => {
+    await purge.handler(['lock']);
+
+    expect(client.message.channel.clone).toHaveBeenCalled();
+
+    expect(otherChannel.send).toHaveBeenCalled();
+    expect(client.message.channel.delete).not.toHaveBeenCalled();
+    expect(client.message.channel.updateOverwrite).toHaveBeenCalled();
+  });
+});

--- a/src/environment.js
+++ b/src/environment.js
@@ -9,7 +9,8 @@ export const environmentElements = [
   'GUILD_ID',
   'BOT_PREFIX',
   'MOD_CHANNEL_ID',
-  'DEV_CHANNEL_ID'
+  'DEV_CHANNEL_ID',
+  'EVENT_QUESTIONS_CHANNEL_ID'
 ];
 
 /**
@@ -35,6 +36,24 @@ export const updateElement = (key, value) => {
  */
 export const get = (arg) => {
   return process.env[arg];
+};
+
+/**
+ * Searches for all environment variables that belong to a channel ID
+ *
+ * @param {string} channelId - channel id to be tested
+ * @returns array of environment IDs that relate to channel
+ */
+export const getElementsForChannelId = (channelId) => {
+  let ids = [];
+
+  for (let envVar of environmentElements) {
+    if (get(envVar) === channelId) {
+      ids.push(envVar);
+    }
+  }
+
+  return ids;
 };
 
 /**


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: resolves #141 also fixes #136

Creates `++settings purge` to kill current channel and create new one

### Pull request checklist

- [x] Branch and PR are named correctly
- [x] Updated relevant documentation
- [x] Tested with a tester bot
- [x] Wrote unit tests for changes

### Testing instructions

1. go into channel
2. `++settings purge` 
3. channel should be cloned
