### PR TITLE
[feature] Add thumbs up bot (basic version)

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       ENV: testing
       MONGODB: mongodb://localhost:27017/megabot
-      PREFIX: ++
+      BOT_PREFIX: ++
       MOD_CHANNEL_ID: 123
       GUILD_ID: 321
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "megabot",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "CSCH megabot with standalone packages",
   "main": "src/index.js",
   "repository": "https://github.com/cscareerhub/megabot.git",

--- a/src/bots/misc/events/onMessage.js
+++ b/src/bots/misc/events/onMessage.js
@@ -1,0 +1,22 @@
+import { get } from '../../../environment';
+
+const thumbsUp = '👍';
+
+/**
+ * Thumbs up reaction in event questions channel
+ *
+ * @param {Message} message Message object that is to be reacted to
+ */
+let onEventQuestion = async (message) => {
+  if (message.channel.id !== get('EVENT_QUESTIONS_CHANNEL_ID')) {
+    return;
+  }
+
+  if (message.author.bot) {
+    return;
+  }
+
+  await message.react(thumbsUp);
+};
+
+export default onEventQuestion;

--- a/src/bots/misc/events/tests/onMessage.test.js
+++ b/src/bots/misc/events/tests/onMessage.test.js
@@ -1,0 +1,41 @@
+import onEventQuestion from '../onMessage';
+import * as env from '../../../../environment';
+
+describe('onMessage', () => {
+  const message = {
+    author: {
+      bot: false
+    },
+    channel: {
+      id: '777'
+    },
+    react: jest.fn()
+  };
+
+  test('nothing happens when wrong channel', async () => {
+    jest.spyOn(env, 'get').mockImplementationOnce(() => '111');
+    message.author.bot = false;
+
+    await onEventQuestion(message);
+
+    expect(message.react).not.toHaveBeenCalled();
+  });
+
+  test('nothing happens when author is bot', async () => {
+    jest.spyOn(env, 'get').mockImplementationOnce(() => '777');
+    message.author.bot = true;
+
+    await onEventQuestion(message);
+
+    expect(message.react).not.toHaveBeenCalled();
+  });
+
+  test('react happens when correct channel', async () => {
+    jest.spyOn(env, 'get').mockImplementationOnce(() => '777');
+    message.author.bot = false;
+
+    await onEventQuestion(message);
+
+    expect(message.react).toHaveBeenCalledWith('👍');
+  });
+});

--- a/src/bots/misc/index.js
+++ b/src/bots/misc/index.js
@@ -1,6 +1,7 @@
 import client from '../../client';
 import { commandHandler } from '../../utils';
 import lmgtfy from './subCommands/lmgtfy';
+import onEventQuestion from './events/onMessage';
 import pm from './subCommands/privateMessage';
 
 const subCommands = {
@@ -9,3 +10,12 @@ const subCommands = {
 };
 
 client.on('misc', () => commandHandler(subCommands));
+
+client.on('message', (message) => {
+  //Don't upvote commands
+  if (message.content.startsWith(client.prefix)) {
+    return;
+  }
+
+  onEventQuestion(message);
+});

--- a/src/bots/settings/index.js
+++ b/src/bots/settings/index.js
@@ -2,12 +2,14 @@ import client from '../../client';
 import { commandHandler } from '../../utils';
 import purge from './subCommands/purgeChannel';
 import setDevChannel from './subCommands/setDevChannel';
+import setEventChannel from './subCommands/setEventChannel';
 import setModChannel from './subCommands/setModChannel';
 import updateElement from './subCommands/updateEnvVar';
 
 const subCommands = {
   purge: purge,
   setDevChannel: setDevChannel,
+  setEventChannel: setEventChannel,
   setModChannel: setModChannel,
   update: updateElement
 };

--- a/src/bots/settings/subCommands/setEventChannel.js
+++ b/src/bots/settings/subCommands/setEventChannel.js
@@ -1,0 +1,27 @@
+import client from '../../../client';
+import { insufficientPermissionsAlert } from '../../../utils/perms';
+import { strings } from '../constants';
+import { updateElement } from '../../../environment';
+
+/**
+ * Handles setting of event channel with bot
+ */
+const handler = async () => {
+  if (insufficientPermissionsAlert()) {
+    return;
+  }
+
+  updateElement('EVENT_QUESTIONS_CHANNEL_ID', client.message.channel.id);
+
+  client.message.channel.send(
+    strings.successfullyUpdated('event questions channel', 'the current one')
+  );
+};
+
+const setDevChannel = {
+  example: 'setEventChannel',
+  handler,
+  usage: 'Sets mod retrieval channel to wherever command is called from.'
+};
+
+export default setDevChannel;

--- a/src/bots/settings/subCommands/tests/setEventChannel.test.js
+++ b/src/bots/settings/subCommands/tests/setEventChannel.test.js
@@ -1,0 +1,38 @@
+import client from '../../../../client';
+import setEventChannel from '../setEventChannel';
+import * as permUtils from '../../../../utils/perms';
+
+describe('setting event channel', () => {
+  beforeEach(async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementation(() => false);
+
+    client.message = {
+      channel: {
+        id: 12321,
+        send: jest.fn()
+      }
+    };
+  });
+
+  test('insufficient permissions returns early', async () => {
+    jest
+      .spyOn(permUtils, 'insufficientPermissionsAlert')
+      .mockImplementationOnce(() => true);
+
+    await setEventChannel.handler();
+
+    expect(client.message.channel.send).not.toHaveBeenCalled();
+  });
+
+  test('settings updates event channel ID', async () => {
+    await setEventChannel.handler();
+
+    expect(process.env['EVENT_QUESTIONS_CHANNEL_ID']).toEqual('12321');
+
+    expect(client.message.channel.send).toHaveBeenCalledWith(
+      'The event questions channel has been updated to the current one.'
+    );
+  });
+});


### PR DESCRIPTION
### Purpose of pull request

**Related Issue**: resolves #140

Gives bot thumbs up ability in event questions channel (must be set first with update setEventChannel)

### Pull request checklist

- [x] Branch and PR are named correctly
- [x] Updated relevant documentation
- [x] Tested with a tester bot
- [x] Wrote unit tests for changes

### Testing instructions

- ++settings setEventChannel
- send a message in the event questions channel
